### PR TITLE
Fixed a problem that it did not work depending on the version of hugo.

### DIFF
--- a/layouts/partials/head/styling.html
+++ b/layouts/partials/head/styling.html
@@ -2,6 +2,6 @@
 {{ $css := resources.Get "css/main.css" }}
 {{ $css = $css | resources.PostCSS }}
 {{ if hugo.IsProduction }}
-  {{ $css = $css | fingerprint | resources.PostProcess }}
+  {{ $css = $css | fingerprint | css.PostProcess }}
 {{ end }}
 <link href="{{ $css.Permalink }}" rel="stylesheet" />


### PR DESCRIPTION
Fixed resources.PostCSS is no longer available since version v0.128.0 of hugo.

## What I did

I followed the readme.md and when I started the server, an error occurred.

1. Clone repository
`git submodule add https://github.com/janraasch/hugo-product-launch.git themes/hugo-product-launch`
2. Copy files in examplesSite
`cp -r themes/hugo-product-launch/exampleSite/* .`
3. Install libs
`npm install && npm install postcss-cli postcss -g`
4. Copy `assets/css/main.cs` & `tailwind.config.js` to my project root
5. Copy `postcss.config.js` to my project root
6. Rename `config.toml` to `hugo.toml`
7. Run debug server
`hugo server -D`

### Execution Result

```shell-session
% hugo server -D
Watching for changes in /Users/135yshr/go/src/github.com/135yshr/godwork-site/{archetypes,assets,content,data,i18n,package.json,postcss.config.js,static,tailwind.config.js,themes}
Watching for config changes in /Users/135yshr/go/src/github.com/135yshr/godwork-site/hugo.toml, /Users/135yshr/go/src/github.com/135yshr/godwork-site/go.mod
Start building sites …
hugo v0.140.2+extended+withdeploy darwin/arm64 BuildDate=2024-12-30T15:01:53Z VendorInfo=brew

WARN  Raw HTML omitted while rendering "/Users/135yshr/go/src/github.com/135yshr/godwork-site/content/_index.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-goldmark-raw-html']
ERROR deprecated: resources.PostCSS was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.141.0. Use css.PostCSS instead.
Built in 1777 ms
Error: error building site: logged 1 error(s)
```
## Related sites

- https://gohugo.io/functions/resources/postcss/