### PR TITLE
Adding method option to form shortcode parameters

### DIFF
--- a/layouts/shortcodes/contact_form.html
+++ b/layouts/shortcodes/contact_form.html
@@ -1,5 +1,6 @@
 <form
   {{ with .Get "action" }}action="{{ . }}"{{ end }}
+  {{ with .Get "method" }}method="{{ . }}"{{ end }}
   id="{{ with .Get "id" }}{{ . }}{{ else }}contact-form{{ end }}"
   class="pb-10"
   name="contact"

--- a/layouts/shortcodes/newsletter_sign_up.html
+++ b/layouts/shortcodes/newsletter_sign_up.html
@@ -1,5 +1,6 @@
 <form
   {{ with .Get "action" }}action="{{ . }}"{{ end }}
+  {{ with .Get "method" }}method="{{ . }}"{{ end }}
   class="pb-10"
   id="{{ with .Get "id" }}{{ . }}{{ else }}newsletter-sign-up-form{{ end }}"
   name="newsletter"


### PR DESCRIPTION
Some services require POST method (such as formsubmit.co). Adding this option allows it to work with this service